### PR TITLE
Refactor `troo show <resource> <id>`;

### DIFF
--- a/lib/troo/actions/create_board.rb
+++ b/lib/troo/actions/create_board.rb
@@ -21,7 +21,7 @@ module Troo
     attr_reader :name, :description
 
     def update_boards
-      return Troo::BoardPersistence.for(create_board) if create_board
+      return BoardPersistence.for(create_board) if create_board
       false
     end
 

--- a/lib/troo/actions/create_card.rb
+++ b/lib/troo/actions/create_card.rb
@@ -20,7 +20,7 @@ module Troo
     attr_reader :list, :name, :description
 
     def update_cards
-      return Troo::CardPersistence.for(create_card) if create_card
+      return CardPersistence.for(create_card) if create_card
       false
     end
 

--- a/lib/troo/actions/create_comment.rb
+++ b/lib/troo/actions/create_comment.rb
@@ -19,7 +19,7 @@ module Troo
     attr_reader :card, :comment
 
     def update_comments
-      return Troo::CommentPersistence.for(parsed_json_response) if parsed_json_response
+      return CommentPersistence.for(parsed_json_response) if parsed_json_response
       false
     end
 

--- a/lib/troo/actions/create_list.rb
+++ b/lib/troo/actions/create_list.rb
@@ -19,7 +19,7 @@ module Troo
     attr_reader :board, :name
 
     def update_lists
-      return Troo::ListPersistence.for(create_list) if create_list
+      return ListPersistence.for(create_list) if create_list
       false
     end
 

--- a/lib/troo/cli/add_cli.rb
+++ b/lib/troo/cli/add_cli.rb
@@ -10,7 +10,7 @@ module Troo
           name = ask("Please enter a name for this board:")
         end
 
-        if result = Troo::CreateBoard.with(name, description)
+        if result = CreateBoard.with(name, description)
           say "New board '#{result.name}' created."
         else
           say "Board could not be created."
@@ -26,8 +26,8 @@ module Troo
           name = ask("Please enter a name for this card:")
         end
 
-        if list = Troo::ListRetrieval.retrieve(list_id)
-          if result = Troo::CreateCard.for(list, name, description)
+        if list = ListRetrieval.retrieve(list_id)
+          if result = CreateCard.for(list, name, description)
             say "New card '#{result.name}' created."
           else
             say "Card could not be created."
@@ -46,8 +46,8 @@ module Troo
           comment = ask("Please enter a comment:")
         end
 
-        if card = Troo::CardRetrieval.retrieve(card_id)
-          if Troo::CreateComment.for(card, comment)
+        if card = CardRetrieval.retrieve(card_id)
+          if CreateComment.for(card, comment)
             say "New comment created."
           else
             say "Comment could not be created."
@@ -66,8 +66,8 @@ module Troo
           name = ask("Please enter a name for this list:")
         end
 
-        if board = Troo::BoardRetrieval.retrieve(board_id)
-          if result = Troo::CreateList.for(board, name)
+        if board = BoardRetrieval.retrieve(board_id)
+          if result = CreateList.for(board, name)
             say "New list '#{result.name}' created."
           else
             say "List could not be created."

--- a/lib/troo/cli/cli_helpers.rb
+++ b/lib/troo/cli/cli_helpers.rb
@@ -1,16 +1,27 @@
 module Troo
   module CLI
     module Helpers
+      def set_default
+        return success if resource && resource.set_default!
+        not_found
+      end
+
+      def success
+        say "'#{resource.name}' set as default #{type.to_s.downcase}."
+        true
+      end
+
+      def not_found
+        say "#{type.to_s.capitalize} cannot be found. Specify a different <id> or use 'troo default #{type.to_s} <id>' to set a default #{type.to_s} first."
+        false
+      end
+
       def resource
         @resource ||= case type
         when :board then BoardRetrieval.retrieve(id)
         when :list  then ListRetrieval.retrieve(id)
         when :card  then CardRetrieval.retrieve(id)
         end
-      end
-
-      def not_found
-        say "#{type.to_s.capitalize} cannot be found."
       end
     end
 

--- a/lib/troo/cli/cli_helpers.rb
+++ b/lib/troo/cli/cli_helpers.rb
@@ -1,0 +1,23 @@
+module Troo
+  module CLI
+    module Helpers
+      def resource
+        @resource ||= case type
+        when :board then BoardRetrieval.retrieve(id)
+        when :list  then ListRetrieval.retrieve(id)
+        when :card  then CardRetrieval.retrieve(id)
+        end
+      end
+
+      def not_found
+        say "#{type.to_s.capitalize} cannot be found."
+      end
+    end
+
+    class ThorFixes < Thor
+      def self.banner(command, namespace = nil, subcommand = false)
+        "#{basename} #{@package_name} #{command.usage}"
+      end
+    end
+  end
+end

--- a/lib/troo/cli/default_cli.rb
+++ b/lib/troo/cli/default_cli.rb
@@ -1,6 +1,8 @@
 module Troo
   module CLI
     class Default < ThorFixes
+      include Helpers
+
       package_name "default"
 
       desc "board <id>", "Set the board <id> to default."
@@ -19,6 +21,7 @@ module Troo
       end
 
       private
+      attr_reader :id, :type
 
       def set_default(id, type)
         @id, @type = id, type
@@ -26,20 +29,8 @@ module Troo
         not_found
       end
 
-      def resource
-        @resource ||= case @type
-        when :board then BoardRetrieval.retrieve(@id)
-        when :list  then ListRetrieval.retrieve(@id)
-        when :card  then CardRetrieval.retrieve(@id)
-        end
-      end
-
       def success(resource_name = "")
-        say "'#{resource_name}' set as default #{@type.to_s.downcase}."
-      end
-
-      def not_found
-        say "#{@type.to_s.capitalize} cannot be found."
+        say "'#{resource_name}' set as default #{type.to_s.downcase}."
       end
     end
   end

--- a/lib/troo/cli/default_cli.rb
+++ b/lib/troo/cli/default_cli.rb
@@ -7,30 +7,25 @@ module Troo
 
       desc "board <id>", "Set the board <id> to default."
       def board(id)
-        set_default(id, :board)
+        initialize_and_dispatch(id, :board)
       end
 
       desc "card <id>", "Set the card <id> to default."
       def card(id)
-        set_default(id, :card)
+        initialize_and_dispatch(id, :card)
       end
 
       desc "list <id>", "Set the list <id> to default."
       def list(id)
-        set_default(id, :list)
+        initialize_and_dispatch(id, :list)
       end
 
       private
       attr_reader :id, :type
 
-      def set_default(id, type)
+      def initialize_and_dispatch(id, type)
         @id, @type = id, type
-        return success(resource.name) if SetDefault.for(resource)
-        not_found
-      end
-
-      def success(resource_name = "")
-        say "'#{resource_name}' set as default #{type.to_s.downcase}."
+        set_default
       end
     end
   end

--- a/lib/troo/cli/default_cli.rb
+++ b/lib/troo/cli/default_cli.rb
@@ -28,9 +28,9 @@ module Troo
 
       def resource
         @resource ||= case @type
-        when :board then Troo::BoardRetrieval.retrieve(@id)
-        when :list  then Troo::ListRetrieval.retrieve(@id)
-        when :card  then Troo::CardRetrieval.retrieve(@id)
+        when :board then BoardRetrieval.retrieve(@id)
+        when :list  then ListRetrieval.retrieve(@id)
+        when :card  then CardRetrieval.retrieve(@id)
         end
       end
 

--- a/lib/troo/cli/main_cli.rb
+++ b/lib/troo/cli/main_cli.rb
@@ -12,7 +12,7 @@ module Troo
         card_count  = Troo::Card.count
 
         if board_count > 0
-          if board = Troo::BoardRetrieval.default
+          if board = BoardRetrieval.default
             say "Board: #{BoardDecorator.new(board).short}"
           else
             say "Board: No default set."
@@ -22,7 +22,7 @@ module Troo
         end
 
         if list_count > 0
-          if list = Troo::ListRetrieval.default
+          if list = ListRetrieval.default
             say "List: #{ListDecorator.new(list).short}"
           else
             say "List: No default set."
@@ -32,7 +32,7 @@ module Troo
         end
 
         if card_count > 0
-          if card = Troo::CardRetrieval.default
+          if card = CardRetrieval.default
             say "Card: #{CardDecorator.new(card).short}"
           else
             say "Card: No default set."
@@ -66,7 +66,7 @@ module Troo
           RefreshAll.all(nil, options)
           say "All local data has been refreshed."
         else
-          if board = Troo::BoardRetrieval.default
+          if board = BoardRetrieval.default
             if options["lists"]
               RefreshAll.lists(board, options)
               say "All lists for the default board have been refreshed."
@@ -109,8 +109,8 @@ module Troo
 
       desc "move <card_id> <list_id>", "Move a card <card_id> to list <list_id>."
       def move(card_id, list_id)
-        if card = Troo::CardRetrieval.retrieve(card_id)
-          if list = Troo::ListRetrieval.retrieve(list_id)
+        if card = CardRetrieval.retrieve(card_id)
+          if list = ListRetrieval.retrieve(list_id)
             if result = MoveCard.with(card, list)
               say "Card moved from '#{card.list.name}' to '#{list.name}'."
             else

--- a/lib/troo/cli/main_cli.rb
+++ b/lib/troo/cli/main_cli.rb
@@ -13,7 +13,7 @@ module Troo
 
         if board_count > 0
           if board = BoardRetrieval.default
-            say "Board: #{BoardDecorator.new(board).short}"
+            say "Board: #{board.decorator.short}"
           else
             say "Board: No default set."
           end
@@ -23,7 +23,7 @@ module Troo
 
         if list_count > 0
           if list = ListRetrieval.default
-            say "List: #{ListDecorator.new(list).short}"
+            say "List: #{list.decorator.short}"
           else
             say "List: No default set."
           end
@@ -33,7 +33,7 @@ module Troo
 
         if card_count > 0
           if card = CardRetrieval.default
-            say "Card: #{CardDecorator.new(card).short}"
+            say "Card: #{card.decorator.short}"
           else
             say "Card: No default set."
           end

--- a/lib/troo/cli/show_cli.rb
+++ b/lib/troo/cli/show_cli.rb
@@ -1,6 +1,8 @@
 module Troo
   module CLI
     class Show < ThorFixes
+      include Helpers
+
       package_name "show"
 
       desc "boards", "Show all the boards with lists."
@@ -47,6 +49,7 @@ module Troo
       end
 
       private
+      attr_reader :id, :type
 
       def show(id, type)
         @id, @type = id, type
@@ -65,27 +68,15 @@ module Troo
       end
 
       def presenter
-        @presenter ||= case @type
+        @presenter ||= case type
         when :board    then BoardPresenter.render_show(resource)
         when :list     then ListPresenter.render_show(resource)
         when :card     then CardPresenter.render_show(resource)
         end
       end
 
-      def resource
-        @resource ||= case @type
-        when :board    then BoardRetrieval.retrieve(@id)
-        when :list     then ListRetrieval.retrieve(@id)
-        when :card     then CardRetrieval.retrieve(@id)
-        end
-      end
-
-      def not_found
-        say "#{@type.to_s.capitalize} cannot be found."
-      end
-
       def not_found_no_default
-        say "Specify an <id> or use 'troo default #{@type.to_s} <id>' to set a default #{@type.to_s} first."
+        say "Specify an <id> or use 'troo default #{type.to_s} <id>' to set a default #{type.to_s} first."
       end
     end
   end

--- a/lib/troo/cli/show_cli.rb
+++ b/lib/troo/cli/show_cli.rb
@@ -5,7 +5,7 @@ module Troo
 
       desc "boards", "Show all the boards with lists."
       def boards
-        boards = Troo::BoardRetrieval.all
+        boards = BoardRetrieval.all
         if boards.any?
           boards.map do |board|
             BoardPresenter.render_all(board)
@@ -15,68 +15,77 @@ module Troo
         end
       end
 
-      desc "board (<board_id>)", "Show lists and cards for board <board_id> (uses default board if <board_id> not provided)."
-      def board(board_id = nil)
-        if board = Troo::BoardRetrieval.retrieve(board_id)
-          if SetDefault.for(board)
-            say "'#{board.name}' set to default."
-          end
-          BoardPresenter.render_show(board)
-        else
-          if board_id
-            say "Board not found."
-          else
-            say "Specify a <board_id> or use 'troo default board <board_id>' to set a default board first."
-          end
-        end
+      desc "board (<id>)", "Show lists and cards for board <id> (uses default board if <id> not provided)."
+      def board(id = nil)
+        show(id, :board)
       end
 
-      desc "list (<list_id>)", "Show all cards for list <list_id> (uses default list if <list_id> not provided)."
-      def list(list_id = nil)
-        if list = Troo::ListRetrieval.retrieve(list_id)
-          if SetDefault.for(list)
-            say "'#{list.name}' set to default."
-          end
-          ListPresenter.render_show(list)
-        else
-          if list_id
-            say "List not found."
-          else
-            say "Specify a <list_id> or use 'troo default list <list_id>' to set a default list first."
-          end
-        end
+      desc "list (<id>)", "Show all cards for list <id> (uses default list if <id> not provided)."
+      def list(id = nil)
+        show(id, :list)
       end
 
-      desc "card (<card_id>)", "Show a card including latest 3 comments for card <card_id> (uses default card if <card_id> not provided)."
-      def card(card_id = nil)
-        if card = Troo::CardRetrieval.retrieve(card_id)
-          if SetDefault.for(card)
-            say "'#{card.name}' set to default."
-          end
-          CardPresenter.render_show(card)
-        else
-          if card_id
-            say "Card not found."
-          else
-            say "Specify a <card_id> or use 'troo default card <card_id>' to set a default card first."
-          end
-        end
+      desc "card (<id>)", "Show a card including latest 3 comments for card <id> (uses default card if <id> not provided)."
+      def card(id = nil)
+        show(id, :card)
       end
 
-      desc "comments (<card_id>)", "Show all comments for card <card_id> (uses default card if <card_id> not provided)."
-      def comments(card_id = nil)
-        if card = Troo::CardRetrieval.retrieve(card_id)
+      desc "comments (<id>)", "Show all comments for card <id> (uses default card if <id> not provided)."
+      def comments(id = nil)
+        if card = CardRetrieval.retrieve(id)
           if SetDefault.for(card)
             say "'#{card.name}' set to default."
           end
           CommentPresenter.render_show(card)
         else
-          if card_id
-            say "Card not found."
+          if id
+            say "Card cannot be found."
           else
-            say "Specify a <card_id> or use 'troo default card <card_id>' to set a default card first."
+            say "Specify a <id> or use 'troo default card <id>' to set a default card first."
           end
         end
+      end
+
+      private
+
+      def show(id, type)
+        @id, @type = id, type
+        return presenter if set_default
+        not_found
+      end
+
+      def set_default
+        if resource
+          SetDefault.for(resource)
+          true
+        else
+          not_found_no_default
+          false
+        end
+      end
+
+      def presenter
+        @presenter ||= case @type
+        when :board    then BoardPresenter.render_show(resource)
+        when :list     then ListPresenter.render_show(resource)
+        when :card     then CardPresenter.render_show(resource)
+        end
+      end
+
+      def resource
+        @resource ||= case @type
+        when :board    then BoardRetrieval.retrieve(@id)
+        when :list     then ListRetrieval.retrieve(@id)
+        when :card     then CardRetrieval.retrieve(@id)
+        end
+      end
+
+      def not_found
+        say "#{@type.to_s.capitalize} cannot be found."
+      end
+
+      def not_found_no_default
+        say "Specify an <id> or use 'troo default #{@type.to_s} <id>' to set a default #{@type.to_s} first."
       end
     end
   end

--- a/lib/troo/cli/show_cli.rb
+++ b/lib/troo/cli/show_cli.rb
@@ -19,17 +19,17 @@ module Troo
 
       desc "board (<id>)", "Show lists and cards for board <id> (uses default board if <id> not provided)."
       def board(id = nil)
-        show(id, :board)
+        initialize_and_dispatch(id, :board)
       end
 
       desc "list (<id>)", "Show all cards for list <id> (uses default list if <id> not provided)."
       def list(id = nil)
-        show(id, :list)
+        initialize_and_dispatch(id, :list)
       end
 
       desc "card (<id>)", "Show a card including latest 3 comments for card <id> (uses default card if <id> not provided)."
       def card(id = nil)
-        show(id, :card)
+        initialize_and_dispatch(id, :card)
       end
 
       desc "comments (<id>)", "Show all comments for card <id> (uses default card if <id> not provided)."
@@ -38,7 +38,7 @@ module Troo
           if SetDefault.for(card)
             say "'#{card.name}' set to default."
           end
-          CommentPresenter.render_show(card)
+          CommentPresenter.show(card)
         else
           if id
             say "Card cannot be found."
@@ -51,32 +51,13 @@ module Troo
       private
       attr_reader :id, :type
 
-      def show(id, type)
+      def initialize_and_dispatch(id, type)
         @id, @type = id, type
-        return presenter if set_default
-        not_found
+        show_resource
       end
 
-      def set_default
-        if resource
-          SetDefault.for(resource)
-          true
-        else
-          not_found_no_default
-          false
-        end
-      end
-
-      def presenter
-        @presenter ||= case type
-        when :board    then BoardPresenter.render_show(resource)
-        when :list     then ListPresenter.render_show(resource)
-        when :card     then CardPresenter.render_show(resource)
-        end
-      end
-
-      def not_found_no_default
-        say "Specify an <id> or use 'troo default #{type.to_s} <id>' to set a default #{type.to_s} first."
+      def show_resource
+        resource.presenter.show if set_default
       end
     end
   end

--- a/lib/troo/cli/thor_fixes.rb
+++ b/lib/troo/cli/thor_fixes.rb
@@ -1,9 +1,0 @@
-module Troo
-  module CLI
-    class ThorFixes < Thor
-      def self.banner(command, namespace = nil, subcommand = false)
-        "#{basename} #{@package_name} #{command.usage}"
-      end
-    end
-  end
-end

--- a/lib/troo/display/board_presenter.rb
+++ b/lib/troo/display/board_presenter.rb
@@ -5,8 +5,8 @@ module Troo
         new(board, options).render_all
       end
 
-      def render_show(board, options = {})
-        new(board, options).render_show
+      def show(board, options = {})
+        new(board, options).show
       end
     end
 
@@ -19,12 +19,12 @@ module Troo
 
     def render_all
       spacing({foot: false}) do
-        print BoardDecorator.new(board).short
+        print board.decorator.short
 
         if board.lists.any?
           board.lists.each do |list|
             indent do
-              print ListDecorator.new(list).short
+              print list.decorator.short
             end
           end
         else
@@ -33,19 +33,19 @@ module Troo
       end
     end
 
-    def render_show
+    def show
       spacing do
-        print BoardDecorator.new(board).short
+        print board.decorator.short
 
         if board.lists.any?
           board.lists.each do |list|
             indent do
-              print ListDecorator.new(list).short
+              print list.decorator.short
 
               if list.cards.any?
                 list.cards.each do |card|
                   indent do
-                    print CardDecorator.new(card).short
+                    print card.decorator.short
                   end
                 end
               else

--- a/lib/troo/display/card_decorator.rb
+++ b/lib/troo/display/card_decorator.rb
@@ -61,7 +61,7 @@ module Troo
 
     def members
       if card.members.any?
-        MemberPresenter.new(card).render_show
+        MemberPresenter.new(card).show
       else
         "No members have been assigned."
       end
@@ -72,11 +72,11 @@ module Troo
     end
 
     def board
-      BoardDecorator.new(card.board, options).short
+      card.board.decorator(options).short
     end
 
     def list
-      ListDecorator.new(card.list, options).short
+      card.list.decorator(options).short
     end
 
     private
@@ -95,11 +95,11 @@ module Troo
     end
 
     def decorated_recent_comments
-      card.recent_comments.map { |comment| CommentDecorator.new(comment).as_view }.join
+      card.recent_comments.map { |comment| comment.decorator.as_view }.join
     end
 
     def decorated_all_comments
-      card.comments.map { |comment| CommentDecorator.new(comment).as_view }.join
+      card.comments.map { |comment| comment.decorator.as_view }.join
     end
   end
 end

--- a/lib/troo/display/card_presenter.rb
+++ b/lib/troo/display/card_presenter.rb
@@ -1,8 +1,8 @@
 module Troo
   class CardPresenter
     class << self
-      def render_show(card, options = {})
-        new(card, options).render_show
+      def show(card, options = {})
+        new(card, options).show
       end
     end
 
@@ -13,7 +13,7 @@ module Troo
       @options = options
     end
 
-    def render_show
+    def show
       print Template.parse(decorated_card, "/../views/card.erb")
     end
 
@@ -21,7 +21,7 @@ module Troo
     attr_reader :card
 
     def decorated_card
-      @decorated_card ||= CardDecorator.new(card)
+      @decorated_card ||= card.decorator
     end
   end
 end

--- a/lib/troo/display/comment_decorator.rb
+++ b/lib/troo/display/comment_decorator.rb
@@ -2,8 +2,9 @@ module Troo
   class CommentDecorator
     include DecoratorHelpers
 
-    def initialize(comment)
+    def initialize(comment, options = {})
       @comment = comment
+      @options = options
     end
 
     def as_view

--- a/lib/troo/display/comment_presenter.rb
+++ b/lib/troo/display/comment_presenter.rb
@@ -1,8 +1,8 @@
 module Troo
   class CommentPresenter
     class << self
-      def render_show(card, options = {})
-        new(card, options).render_show
+      def show(card, options = {})
+        new(card, options).show
       end
     end
 
@@ -13,14 +13,14 @@ module Troo
       @options = options
     end
 
-    def render_show
+    def show
       spacing do
-        print CardDecorator.new(card).short
+        print card.decorator.short
 
         if card.comments.any?
           card.comments.each do |comment|
             indent do
-              print CommentDecorator.new(comment).as_view
+              print comment.decorator.as_view
             end
           end
         else

--- a/lib/troo/display/list_presenter.rb
+++ b/lib/troo/display/list_presenter.rb
@@ -1,8 +1,8 @@
 module Troo
   class ListPresenter
     class << self
-      def render_show(list, options = {})
-        new(list, options).render_show
+      def show(list, options = {})
+        new(list, options).show
       end
     end
 
@@ -13,17 +13,17 @@ module Troo
       @options = options
     end
 
-    def render_show
+    def show
       spacing do
-        print BoardDecorator.new(board).short
+        print board.decorator.short
 
         indent do
-          print ListDecorator.new(list).short
+          print list.decorator.short
 
           if list.cards.any?
             list.cards.each do |card|
               indent do
-                print CardDecorator.new(card).short
+                print card.decorator.short
               end
             end
           else

--- a/lib/troo/display/member_decorator.rb
+++ b/lib/troo/display/member_decorator.rb
@@ -2,8 +2,9 @@ module Troo
   class MemberDecorator
     include DecoratorHelpers
 
-    def initialize(member)
-      @member = member
+    def initialize(member, options = {})
+      @member  = member
+      @options = options
     end
 
     def username

--- a/lib/troo/display/member_presenter.rb
+++ b/lib/troo/display/member_presenter.rb
@@ -1,8 +1,8 @@
 module Troo
   class MemberPresenter
     class << self
-      def render_show(card, options = {})
-        new(card, options).render_show
+      def show(card, options = {})
+        new(card, options).show
       end
     end
 
@@ -13,7 +13,7 @@ module Troo
       @options = options
     end
 
-    def render_show
+    def show
       decorated_members
     end
 
@@ -33,7 +33,7 @@ module Troo
     end
 
     def members
-      @members ||= card.members.map { |member| MemberDecorator.new(member).username }
+      @members ||= card.members.map { |member| member.decorator.username }
     end
 
     def one_member?

--- a/lib/troo/external/board.rb
+++ b/lib/troo/external/board.rb
@@ -4,13 +4,13 @@ module Troo
       class << self
         def fetch(external_id, options = {})
           new(external_id, options).fetch_by_external_id.map do |resource|
-            Troo::BoardPersistence.for(resource) unless closed?(resource)
+            BoardPersistence.for(resource) unless closed?(resource)
           end
         end
 
         def fetch_all
           new.fetch_all.map do |resource|
-            Troo::BoardPersistence.for(resource) unless closed?(resource)
+            BoardPersistence.for(resource) unless closed?(resource)
           end
         end
       end

--- a/lib/troo/external/card.rb
+++ b/lib/troo/external/card.rb
@@ -6,7 +6,7 @@ module Troo
           new(external_id, options).fetch_by_external_id.map do |resource|
             unless closed?(resource)
               Troo::External::Comment.fetch(resource.id, { mode: :card }) if options.fetch(:comments, true)
-              Troo::CardPersistence.for(resource)
+              CardPersistence.for(resource)
             end
           end
         end

--- a/lib/troo/external/comment.rb
+++ b/lib/troo/external/comment.rb
@@ -4,7 +4,7 @@ module Troo
       class << self
         def fetch(external_id, options = {})
           new(external_id, options).fetch_by_external_id.map do |resource|
-            Troo::CommentPersistence.for(resource)
+            CommentPersistence.for(resource)
           end
         end
       end

--- a/lib/troo/external/list.rb
+++ b/lib/troo/external/list.rb
@@ -4,7 +4,7 @@ module Troo
       class << self
         def fetch(external_id, options = {})
           new(external_id, options).fetch_by_external_id.map do |resource|
-            Troo::ListPersistence.for(resource) unless closed?(resource)
+            ListPersistence.for(resource) unless closed?(resource)
           end
         end
       end

--- a/lib/troo/external/member.rb
+++ b/lib/troo/external/member.rb
@@ -4,7 +4,7 @@ module Troo
       class << self
         def fetch(external_id, options = {})
           new(external_id, options).fetch_by_external_id.map do |resource|
-            Troo::MemberPersistence.for(resource)
+            MemberPersistence.for(resource)
           end
         end
       end

--- a/lib/troo/models/board.rb
+++ b/lib/troo/models/board.rb
@@ -21,6 +21,18 @@ module Troo
     def cards
       Troo::Card.find(external_board_id: self.external_board_id)
     end
+
+    def decorator(options = {})
+      BoardDecorator.new(self, options)
+    end
+
+    def presenter
+      BoardPresenter.new(self)
+    end
+
+    def set_default!
+      SetDefault.for(self)
+    end
   end
 end
 

--- a/lib/troo/models/card.rb
+++ b/lib/troo/models/card.rb
@@ -49,6 +49,18 @@ module Troo
         []
       end
     end
+
+    def decorator(options = {})
+      CardDecorator.new(self, options)
+    end
+
+    def presenter
+      CardPresenter.new(self)
+    end
+
+    def set_default!
+      SetDefault.for(self)
+    end
   end
 end
 

--- a/lib/troo/models/card.rb
+++ b/lib/troo/models/card.rb
@@ -25,11 +25,11 @@ module Troo
     alias_method :default?, :default
 
     def board
-      Troo::BoardRetrieval.retrieve(self.external_board_id)
+      BoardRetrieval.retrieve(self.external_board_id)
     end
 
     def list
-      Troo::ListRetrieval.retrieve(self.external_list_id)
+      ListRetrieval.retrieve(self.external_list_id)
     end
 
     def comments

--- a/lib/troo/models/comment.rb
+++ b/lib/troo/models/comment.rb
@@ -17,15 +17,15 @@ module Troo
     index :external_member_id
 
     def board
-      Troo::BoardRetrieval.retrieve(self.external_board_id)
+      BoardRetrieval.retrieve(self.external_board_id)
     end
 
     def card
-      Troo::CardRetrieval.retrieve(self.external_card_id)
+      CardRetrieval.retrieve(self.external_card_id)
     end
 
     def member
-      Troo::MemberRetrieval.retrieve(self.external_member_id)
+      MemberRetrieval.retrieve(self.external_member_id)
     end
   end
 end

--- a/lib/troo/models/comment.rb
+++ b/lib/troo/models/comment.rb
@@ -27,6 +27,10 @@ module Troo
     def member
       MemberRetrieval.retrieve(self.external_member_id)
     end
+
+    def decorator(options = {})
+      CommentDecorator.new(self, options)
+    end
   end
 end
 

--- a/lib/troo/models/list.rb
+++ b/lib/troo/models/list.rb
@@ -23,5 +23,17 @@ module Troo
     def cards
       Troo::Card.find(external_list_id: self.external_list_id)
     end
+
+    def decorator(options = {})
+      ListDecorator.new(self, options)
+    end
+
+    def presenter
+      ListPresenter.new(self)
+    end
+
+    def set_default!
+      SetDefault.for(self)
+    end
   end
 end

--- a/lib/troo/models/list.rb
+++ b/lib/troo/models/list.rb
@@ -17,7 +17,7 @@ module Troo
     alias_method :default?, :default
 
     def board
-      Troo::BoardRetrieval.retrieve(self.external_board_id)
+      BoardRetrieval.retrieve(self.external_board_id)
     end
 
     def cards

--- a/lib/troo/models/member.rb
+++ b/lib/troo/models/member.rb
@@ -13,6 +13,14 @@ module Troo
     attribute :external_member_id
 
     index :external_member_id
+
+    def decorator(options = {})
+      MemberDecorator.new(self, options)
+    end
+
+    def presenter
+      MemberPresenter.new(self)
+    end
   end
 end
 

--- a/lib/troo/troo.rb
+++ b/lib/troo/troo.rb
@@ -65,7 +65,7 @@ require_relative "models/member_retrieval"
 require_relative "models/member_persistence"
 require_relative "models/refresh"
 
-require_relative "cli/thor_fixes"
+require_relative "cli/cli_helpers"
 require_relative "cli/add_cli"
 require_relative "cli/default_cli"
 require_relative "cli/show_cli"

--- a/test/lib/troo/actions/create_board_test.rb
+++ b/test/lib/troo/actions/create_board_test.rb
@@ -8,7 +8,7 @@ module Troo
 
     before do
       @board = Fabricate(:board, name: board_name, description: description)
-      Troo::BoardPersistence.stubs(:for).returns(@board)
+      BoardPersistence.stubs(:for).returns(@board)
     end
 
     after { database_cleanup }

--- a/test/lib/troo/actions/create_card_test.rb
+++ b/test/lib/troo/actions/create_card_test.rb
@@ -11,7 +11,7 @@ module Troo
       @list = Fabricate(:list)
       @card = Fabricate(:card, name: card_name, desc: description)
 
-      Troo::CardPersistence.stubs(:for).returns(@card)
+      CardPersistence.stubs(:for).returns(@card)
     end
 
     after { database_cleanup }

--- a/test/lib/troo/actions/create_comment_test.rb
+++ b/test/lib/troo/actions/create_comment_test.rb
@@ -10,7 +10,7 @@ module Troo
       @card = Fabricate(:card)
       @comment = Fabricate(:comment, text: comment)
 
-      Troo::CommentPersistence.stubs(:for).returns(@comment)
+      CommentPersistence.stubs(:for).returns(@comment)
     end
 
     after { database_cleanup }

--- a/test/lib/troo/actions/create_list_test.rb
+++ b/test/lib/troo/actions/create_list_test.rb
@@ -10,7 +10,7 @@ module Troo
       @board = Fabricate(:board)
       @list = Fabricate(:list, name: list_name)
 
-      Troo::ListPersistence.stubs(:for).returns(@list)
+      ListPersistence.stubs(:for).returns(@list)
     end
 
     after { database_cleanup }

--- a/test/lib/troo/cli/add_cli_test.rb
+++ b/test/lib/troo/cli/add_cli_test.rb
@@ -12,10 +12,10 @@ module Troo
         @comment = Fabricate.build(:comment)
         @list    = Fabricate.build(:list, name: "My New Test List")
 
-        Troo::CreateBoard.stubs(:with).returns(@board)
-        Troo::CreateCard.stubs(:for).returns(@card)
-        Troo::CreateComment.stubs(:for).returns(@comment)
-        Troo::CreateList.stubs(:for).returns(@list)
+        CreateBoard.stubs(:with).returns(@board)
+        CreateCard.stubs(:for).returns(@card)
+        CreateComment.stubs(:for).returns(@comment)
+        CreateList.stubs(:for).returns(@list)
       end
 
       after { database_cleanup }
@@ -42,7 +42,7 @@ module Troo
         end
 
         context "when the board was not created" do
-          before { Troo::CreateBoard.stubs(:with).returns(false) }
+          before { CreateBoard.stubs(:with).returns(false) }
 
           it "returns a polite message" do
             subject.must_match /Board could not be created/
@@ -50,7 +50,7 @@ module Troo
         end
 
         context "when the Trello access token credentials are invalid" do
-          before { Troo::CreateBoard.stubs(:with).raises(Troo::InvalidAccessToken) }
+          before { CreateBoard.stubs(:with).raises(Troo::InvalidAccessToken) }
 
           it "returns a polite message" do
             subject.must_match /access credentials have expired, please renew/
@@ -63,7 +63,7 @@ module Troo
         let(:card_name)   { "My New Test Card" }
         let(:description) { "A very brief description..." }
 
-        before { Troo::ListRetrieval.stubs(:retrieve).returns(@list) }
+        before { ListRetrieval.stubs(:retrieve).returns(@list) }
 
         subject { capture_io { described_class.new.card(list_id, card_name, description) }.join }
 
@@ -85,7 +85,7 @@ module Troo
           end
 
           context "when the card was not created" do
-            before { Troo::CreateCard.stubs(:for).returns(false) }
+            before { CreateCard.stubs(:for).returns(false) }
 
             it "returns a polite message" do
               subject.must_match /Card could not be created/
@@ -93,7 +93,7 @@ module Troo
           end
 
           context "when the Trello access token credentials are invalid" do
-            before { Troo::CreateCard.stubs(:for).raises(Troo::InvalidAccessToken) }
+            before { CreateCard.stubs(:for).raises(Troo::InvalidAccessToken) }
 
             it "returns a polite message" do
               subject.must_match /access credentials have expired, please renew/
@@ -102,7 +102,7 @@ module Troo
         end
 
         context "when the list was not found" do
-          before { Troo::ListRetrieval.stubs(:retrieve).returns(nil) }
+          before { ListRetrieval.stubs(:retrieve) }
 
           it "returns a polite message" do
             subject.must_match /list was not found/
@@ -114,7 +114,7 @@ module Troo
         let(:card_id) { "526d8f19ddb279532e005259" }
         let(:comment) { "A very brief description..." }
 
-        before { Troo::CardRetrieval.stubs(:retrieve).returns(@card) }
+        before { CardRetrieval.stubs(:retrieve).returns(@card) }
 
         subject { capture_io { described_class.new.comment(card_id, comment) }.join }
 
@@ -136,7 +136,7 @@ module Troo
           end
 
           context "when the comment was not created" do
-            before { Troo::CreateComment.stubs(:for).returns(false) }
+            before { CreateComment.stubs(:for).returns(false) }
 
             it "returns a polite message" do
               subject.must_match /Comment could not be created/
@@ -144,7 +144,7 @@ module Troo
           end
 
           context "when the Trello access token credentials are invalid" do
-            before { Troo::CreateComment.stubs(:for).raises(Troo::InvalidAccessToken) }
+            before { CreateComment.stubs(:for).raises(Troo::InvalidAccessToken) }
 
             it "returns a polite message" do
               subject.must_match /access credentials have expired, please renew/
@@ -153,7 +153,7 @@ module Troo
         end
 
         context "when the card was not found" do
-          before { Troo::CardRetrieval.stubs(:retrieve).returns(nil) }
+          before { CardRetrieval.stubs(:retrieve) }
 
           it "returns a polite message" do
             subject.must_match /card was not found/
@@ -165,7 +165,7 @@ module Troo
         let(:board_id)  { "526d8e130a14a9d846001d96" }
         let(:list_name) { "My New List" }
 
-        before { Troo::BoardRetrieval.stubs(:retrieve).returns(@board) }
+        before { BoardRetrieval.stubs(:retrieve).returns(@board) }
 
         subject { capture_io { described_class.new.list(board_id, list_name) }.join }
 
@@ -187,7 +187,7 @@ module Troo
           end
 
           context "when the list was not created" do
-            before { Troo::CreateList.stubs(:for).returns(false) }
+            before { CreateList.stubs(:for).returns(false) }
 
             it "returns a polite message" do
               subject.must_match /List could not be created/
@@ -195,7 +195,7 @@ module Troo
           end
 
           context "when the Trello access token credentials are invalid" do
-            before { Troo::CreateList.stubs(:for).raises(Troo::InvalidAccessToken) }
+            before { CreateList.stubs(:for).raises(Troo::InvalidAccessToken) }
 
             it "returns a polite message" do
               subject.must_match /access credentials have expired, please renew/
@@ -204,7 +204,7 @@ module Troo
         end
 
         context "when the board was not found" do
-          before { Troo::BoardRetrieval.stubs(:retrieve).returns(nil) }
+          before { BoardRetrieval.stubs(:retrieve) }
 
           it "returns a polite message" do
             subject.must_match /board was not found/

--- a/test/lib/troo/cli/cli_helpers_test.rb
+++ b/test/lib/troo/cli/cli_helpers_test.rb
@@ -3,6 +3,9 @@ require "thor"
 
 module Troo
   module CLI
+    module Helpers
+    end
+
     describe ThorFixes do
       let(:described_class) { ThorFixes }
 

--- a/test/lib/troo/cli/default_cli_test.rb
+++ b/test/lib/troo/cli/default_cli_test.rb
@@ -12,7 +12,7 @@ module Troo
         subject { capture_io { described_class.new.board(id) }.join }
 
         context "when the id cannot be found" do
-          before { Troo::BoardRetrieval.stubs(:retrieve).returns(nil) }
+          before { BoardRetrieval.stubs(:retrieve) }
 
           it "returns a polite message" do
             subject.must_match /Board cannot be found/
@@ -22,7 +22,7 @@ module Troo
         context "when the id was found" do
           before do
             @board = Fabricate.build(:board)
-            Troo::BoardRetrieval.stubs(:retrieve).returns(@board)
+            BoardRetrieval.stubs(:retrieve).returns(@board)
           end
 
           it "returns a polite message" do
@@ -36,13 +36,13 @@ module Troo
 
         before do
           @card  = Fabricate.build(:card)
-          Troo::CardRetrieval.stubs(:retrieve).returns(@card)
+          CardRetrieval.stubs(:retrieve).returns(@card)
         end
 
         subject { capture_io { described_class.new.card(id) }.join }
 
         context "when the id cannot be found" do
-          before { Troo::CardRetrieval.stubs(:retrieve).returns(nil) }
+          before { CardRetrieval.stubs(:retrieve) }
 
           it "returns a polite message" do
             subject.must_match /Card cannot be found/
@@ -62,7 +62,7 @@ module Troo
         subject { capture_io { described_class.new.list(id) }.join }
 
         context "when the id cannot be found" do
-          before { Troo::ListRetrieval.stubs(:retrieve).returns(nil) }
+          before { ListRetrieval.stubs(:retrieve) }
 
           it "returns a polite message" do
             subject.must_match /List cannot be found/
@@ -72,7 +72,7 @@ module Troo
         context "when the id was found" do
           before do
             @list = Fabricate.build(:list)
-            Troo::ListRetrieval.stubs(:retrieve).returns(@list)
+            ListRetrieval.stubs(:retrieve).returns(@list)
           end
 
           it "returns a polite message" do

--- a/test/lib/troo/cli/main_cli_test.rb
+++ b/test/lib/troo/cli/main_cli_test.rb
@@ -26,7 +26,7 @@ module Troo
         end
 
         context "when a default board is not set" do
-          before { Troo::BoardRetrieval.stubs(:default).returns(nil) }
+          before { BoardRetrieval.stubs(:default) }
 
           it "returns a polite message" do
             subject.must_match /Board: No default/
@@ -40,7 +40,7 @@ module Troo
         end
 
         context "when a default list is not set" do
-          before { Troo::ListRetrieval.stubs(:default).returns(nil) }
+          before { ListRetrieval.stubs(:default) }
 
           it "returns a polite message" do
             subject.must_match /List: No default/
@@ -54,7 +54,7 @@ module Troo
         end
 
         context "when a default card is not set" do
-          before { Troo::CardRetrieval.stubs(:default).returns(nil) }
+          before { CardRetrieval.stubs(:default) }
 
           it "returns a polite message" do
             subject.must_match /Card: No default/
@@ -94,7 +94,7 @@ module Troo
         before do
           RefreshAll.stubs(:all)
           RefreshAll.stubs(:default)
-          Troo::BoardRetrieval.stubs(:default).returns(default)
+          BoardRetrieval.stubs(:default).returns(default)
           RefreshAll.stubs(:lists)
           RefreshAll.stubs(:cards)
         end
@@ -187,8 +187,8 @@ module Troo
           @card = Fabricate(:card)
           @list = Fabricate(:list)
           Troo::MoveCard.stubs(:with).returns(true)
-          Troo::CardRetrieval.stubs(:retrieve).returns(@card)
-          Troo::ListRetrieval.stubs(:retrieve).returns(@list)
+          CardRetrieval.stubs(:retrieve).returns(@card)
+          ListRetrieval.stubs(:retrieve).returns(@list)
         end
 
         subject { capture_io { described_class.new.move(card_id, list_id) }.join }
@@ -211,7 +211,7 @@ module Troo
           end
 
           context "when the list was not found" do
-            before { Troo::ListRetrieval.stubs(:retrieve).returns(nil) }
+            before { ListRetrieval.stubs(:retrieve) }
 
             it "returns a polite message" do
               subject.must_match /list was not found/
@@ -220,7 +220,7 @@ module Troo
         end
 
         context "when the card was not found" do
-          before { Troo::CardRetrieval.stubs(:retrieve).returns(nil) }
+          before { CardRetrieval.stubs(:retrieve) }
 
           it "returns a polite message" do
             subject.must_match /card was not found/

--- a/test/lib/troo/cli/show_cli_test.rb
+++ b/test/lib/troo/cli/show_cli_test.rb
@@ -31,7 +31,7 @@ module Troo
         end
 
         context "when no boards exist" do
-          before { Troo::BoardRetrieval.stubs(:all).returns([]) }
+          before { BoardRetrieval.stubs(:all).returns([]) }
 
           it "returns a polite message" do
             subject.must_match /Boards not found./
@@ -52,10 +52,10 @@ module Troo
           end
 
           context "and the board does not exist" do
-            before { Troo::BoardRetrieval.stubs(:retrieve).returns() }
+            before { BoardRetrieval.stubs(:retrieve) }
 
             it "returns a polite message" do
-              subject.must_match /Board not found./
+              subject.must_match /Board cannot be found./
             end
           end
         end
@@ -64,7 +64,7 @@ module Troo
           let(:board_id) { }
 
           context "and the default board is set" do
-            before { Troo::BoardRetrieval.stubs(:retrieve).returns(@board) }
+            before { BoardRetrieval.stubs(:retrieve).returns(@board) }
 
             it "returns the board with all lists and all cards" do
               subject.must_match /Test Board/
@@ -74,7 +74,7 @@ module Troo
           end
 
           context "and the default board is not set" do
-            before { Troo::BoardRetrieval.stubs(:retrieve).returns() }
+            before { BoardRetrieval.stubs(:retrieve) }
 
             it "returns a polite message" do
               subject.must_match /set a default board first/
@@ -96,10 +96,10 @@ module Troo
           end
 
           context "when the list does not exist" do
-            before { Troo::ListRetrieval.stubs(:retrieve).returns() }
+            before { ListRetrieval.stubs(:retrieve) }
 
             it "returns a polite message" do
-              subject.must_match /List not found./
+              subject.must_match /List cannot be found/
             end
           end
         end
@@ -108,7 +108,7 @@ module Troo
           let(:list_id) { }
 
           context "and the default list is set" do
-            before { Troo::ListRetrieval.stubs(:retrieve).returns(@list) }
+            before { ListRetrieval.stubs(:retrieve).returns(@list) }
 
             it "returns the list's board, the list and all cards" do
               subject.must_match /Test Board/
@@ -118,7 +118,7 @@ module Troo
           end
 
           context "and the default list is not set" do
-            before { Troo::ListRetrieval.stubs(:retrieve).returns() }
+            before { ListRetrieval.stubs(:retrieve) }
 
             it "returns a polite message" do
               subject.must_match /set a default list first/
@@ -143,10 +143,10 @@ module Troo
           end
 
           context "when the card does not exist" do
-            before { Troo::CardRetrieval.stubs(:retrieve).returns() }
+            before { CardRetrieval.stubs(:retrieve) }
 
             it "returns a polite message" do
-              subject.must_match /Card not found./
+              subject.must_match /Card cannot be found/
             end
           end
         end
@@ -155,7 +155,7 @@ module Troo
           let(:card_id) { }
 
           context "and the default card is set" do
-            before { Troo::CardRetrieval.stubs(:retrieve).returns(@card) }
+            before { CardRetrieval.stubs(:retrieve).returns(@card) }
 
             it "returns the card details" do
               subject.must_match /\(67\) My Test Card/
@@ -166,7 +166,7 @@ module Troo
           end
 
           context "and the default card is not set" do
-            before { Troo::CardRetrieval.stubs(:retrieve).returns() }
+            before { CardRetrieval.stubs(:retrieve) }
 
             it "returns a polite message" do
               subject.must_match /set a default card first/
@@ -187,10 +187,10 @@ module Troo
           end
 
           context "when the card does not exist" do
-            before { Troo::CardRetrieval.stubs(:retrieve).returns() }
+            before { CardRetrieval.stubs(:retrieve) }
 
             it "returns a polite message" do
-              subject.must_match /Card not found./
+              subject.must_match /Card cannot be found/
             end
           end
         end
@@ -199,7 +199,7 @@ module Troo
           let(:card_id) { }
 
           context "and the default card is set" do
-            before { Troo::CardRetrieval.stubs(:retrieve).returns(@card) }
+            before { CardRetrieval.stubs(:retrieve).returns(@card) }
 
             it "returns the card and all comments" do
               subject.must_match /\(67\) My Test Card/
@@ -208,7 +208,7 @@ module Troo
           end
 
           context "and the default card is not set" do
-            before { Troo::CardRetrieval.stubs(:retrieve).returns() }
+            before { CardRetrieval.stubs(:retrieve) }
 
             it "returns a polite message" do
               subject.must_match /set a default card first/

--- a/test/lib/troo/display/board_decorator_test.rb
+++ b/test/lib/troo/display/board_decorator_test.rb
@@ -71,7 +71,7 @@ module Troo
       end
 
       context "when the board has no description" do
-        before { @board.stubs(:description).returns(nil) }
+        before { @board.stubs(:description) }
 
         it "returns N/A" do
           subject.must_equal("N/A")
@@ -89,7 +89,7 @@ module Troo
       end
 
       context "when the board has no name" do
-        before { @board.stubs(:name).returns(nil) }
+        before { @board.stubs(:name) }
 
         it "returns N/A" do
           subject.must_equal("N/A")

--- a/test/lib/troo/display/board_presenter_test.rb
+++ b/test/lib/troo/display/board_presenter_test.rb
@@ -44,8 +44,8 @@ module Troo
       end
     end
 
-    describe "#render_show" do
-      subject { capture_io { described_class.new(@board, options).render_show }.join }
+    describe "#show" do
+      subject { capture_io { described_class.show(@board, options) }.join }
 
       context "when the board has lists" do
         context "and the list has cards" do

--- a/test/lib/troo/display/card_presenter_test.rb
+++ b/test/lib/troo/display/card_presenter_test.rb
@@ -25,8 +25,8 @@ module Troo
       end
     end
 
-    describe "#render_show" do
-      subject { capture_io { described_class.render_show(@card, options) }.join }
+    describe "#show" do
+      subject { capture_io { described_class.show(@card, options) }.join }
 
       it "renders the view" do
         subject.must_match /My Test Card/

--- a/test/lib/troo/display/comment_decorator_test.rb
+++ b/test/lib/troo/display/comment_decorator_test.rb
@@ -4,6 +4,7 @@ module Troo
   describe CommentDecorator do
     let(:described_class) { CommentDecorator }
     let(:default) { true }
+    let(:options) { {} }
 
     before do
       @comment = Fabricate(:comment)
@@ -13,10 +14,14 @@ module Troo
     after { database_cleanup }
 
     describe "#initialize" do
-      subject { described_class.new(@comment) }
+      subject { described_class.new(@comment, options) }
 
       it "assigns the comment to an instance variable" do
         subject.instance_variable_get("@comment").must_equal(@comment)
+      end
+
+      it "assigns the options to an instance variable" do
+        subject.instance_variable_get("@options").must_equal(options)
       end
     end
 

--- a/test/lib/troo/display/comment_presenter_test.rb
+++ b/test/lib/troo/display/comment_presenter_test.rb
@@ -25,8 +25,8 @@ module Troo
       end
     end
 
-    describe "#render_show" do
-      subject { capture_io { described_class.render_show(@card, options) }.join }
+    describe "#show" do
+      subject { capture_io { described_class.show(@card, options) }.join }
 
       context "when the card has comments" do
         it "renders the view" do

--- a/test/lib/troo/display/list_presenter_test.rb
+++ b/test/lib/troo/display/list_presenter_test.rb
@@ -25,8 +25,8 @@ module Troo
       end
     end
 
-    describe "#render_show" do
-      subject { capture_io { described_class.new(@list, options).render_show }.join }
+    describe "#show" do
+      subject { capture_io { described_class.show(@list, options) }.join }
 
       context "when the list has cards" do
         it "renders the view" do

--- a/test/lib/troo/display/member_decorator_test.rb
+++ b/test/lib/troo/display/member_decorator_test.rb
@@ -3,15 +3,20 @@ require_relative "../../../test_helper"
 module Troo
   describe MemberDecorator do
     let(:described_class) { MemberDecorator }
+    let(:options) { {} }
 
     before { @member = Fabricate(:member) }
     after  { database_cleanup }
 
     describe "#initialize" do
-      subject { described_class.new(@member) }
+      subject { described_class.new(@member, options) }
 
       it "assigns the member to an instance variable" do
         subject.instance_variable_get("@member").must_equal(@member)
+      end
+
+      it "assigns the options to an instance variable" do
+        subject.instance_variable_get("@options").must_equal(options)
       end
     end
 

--- a/test/lib/troo/display/member_presenter_test.rb
+++ b/test/lib/troo/display/member_presenter_test.rb
@@ -25,8 +25,8 @@ module Troo
       end
     end
 
-    describe "#render_show" do
-      subject { described_class.render_show(@card, options) }
+    describe "#show" do
+      subject { described_class.show(@card, options) }
 
       context "when there is one member" do
         it "returns the member" do


### PR DESCRIPTION
- Reduce duplication in this class.
- Remove Troo namespace where safe to do so.
- Remove pointless (empty/nil) returns from stubs.
